### PR TITLE
use RestTemplate to make calls to datacite

### DIFF
--- a/api-svc/raid-api/src/main/java/au/org/raid/api/factory/DatacitePayloadFactory.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/factory/DatacitePayloadFactory.java
@@ -124,7 +124,7 @@ public class DatacitePayloadFactory {
         }
     }
 
-    public String payloadForCreate(RaidCreateRequest request, String handle){
+    public ObjectNode payloadForCreate(RaidCreateRequest request, String handle){
         ObjectMapper objectMapper = new ObjectMapper();
         ObjectNode rootNode = objectMapper.createObjectNode();
 
@@ -190,9 +190,9 @@ public class DatacitePayloadFactory {
         // DESCRIPTIONS
         createDescriptionNode(attributesNode, request.getDescription());
 
-        return rootNode.toString();
+        return rootNode;
     }
-    public String payloadForUpdate(RaidUpdateRequest request, String handle){
+    public ObjectNode payloadForUpdate(RaidUpdateRequest request, String handle){
         ObjectMapper objectMapper = new ObjectMapper();
         ObjectNode rootNode = objectMapper.createObjectNode();
 
@@ -258,6 +258,6 @@ public class DatacitePayloadFactory {
         // DESCRIPTIONS
         createDescriptionNode(attributesNode, request.getDescription());
 
-        return rootNode.toString();
+        return rootNode;
     }
 }

--- a/api-svc/raid-api/src/main/java/au/org/raid/api/service/raid/RaidStableV1Service.java
+++ b/api-svc/raid-api/src/main/java/au/org/raid/api/service/raid/RaidStableV1Service.java
@@ -99,7 +99,7 @@ public class RaidStableV1Service {
                 metaSvc::formatRaidoLandingPageUrl);
 
         // TODO: Replace apids with datacite handle creation
-        String dataciteHandle = dataciteSvc.getDataciteHandle();
+        String dataciteHandle = dataciteSvc.mintDataciteHandle();
         apidsResponse.identifier.handle = dataciteHandle;
         dataciteSvc.createDataciteRaid(request, dataciteHandle);
 
@@ -109,8 +109,6 @@ public class RaidStableV1Service {
 
         final var raidDto = raidHistoryService.save(request);
         final var raidRecord = raidRecordFactory.create(raidDto);
-
-
 
         tx.executeWithoutResult(status -> raidRepository.insert(raidRecord));
 


### PR DESCRIPTION
- Refactor payloadForCreate method to return ObjectNode instead of String.
- Implement RestTemplate calls and refactor DataciteService for improved code organisation and efficiency.
- Refactor Datacite handle generation and remove redundant raid record insertion in mintRaidSchemaV1.